### PR TITLE
Duplicate count error

### DIFF
--- a/frontend/js/action-creators/duplicate-database-actions.js
+++ b/frontend/js/action-creators/duplicate-database-actions.js
@@ -57,10 +57,11 @@ export function fetchCount() {
         if (response.status == HttpStatus.OK) {
 
           response.text().then(res => {
-            if (isNaN(res)) {
+            const json = JSON.parse(res);
+            if (isNaN(json.count)) {
               return dispatch(fetchDuplicateCountError('Duplicate count was not a number'));
             }
-            dispatch(fetchDuplicateCountSuccess(parseInt(res)));
+            dispatch(fetchDuplicateCountSuccess(parseInt(json.count)));
           });
 
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,8 +94,9 @@
       }
     },
     "@natlibfi/melinda-ui-commons": {
-      "version": "git+https://github.com/NatLibFi/melinda-ui-commons.git#5c12c7eca430d1cb9cdb0538caaf6f4d580c28a0",
-      "from": "git+https://github.com/NatLibFi/melinda-ui-commons.git#melkehitys-984",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@natlibfi/melinda-ui-commons/-/melinda-ui-commons-4.0.1.tgz",
+      "integrity": "sha512-C7O8GWXEtMEvqX7aTSxjrOgyx5wZbCILj00Bn+z5OcjiRmkor+3vYXochnG2l9ci0ku56SjIGzWKSSYiDpYaWw==",
       "requires": {
         "@natlibfi/melinda-api-client": "^2.0.0",
         "body-parser": "^1.18.2",
@@ -118,13 +119,6 @@
         "node-uuid": "^1.4.8",
         "winston": "^2.4.0",
         "xml2js": "^0.4.19"
-      },
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        }
       }
     },
     "@sinonjs/commons": {
@@ -9463,8 +9457,7 @@
     "node-uuid": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "nodemon": {
       "version": "1.19.3",

--- a/server/duplicate-db-controller.js
+++ b/server/duplicate-db-controller.js
@@ -51,7 +51,7 @@ duplicateDatabaseController.options('/pairs/:id/mark-as-not-duplicates', cors(co
 duplicateDatabaseController.get('/pairs/count', cors(corsOptions), (req, res) => {
 
   getDuplicateCount()
-    .then(count => res.send(count))
+    .then(count => res.send({count}))
     .catch(error => {
       logger.log('error', error);
       res.sendStatus(HttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
77 is double count 
```
2019-12-05T10:33:15+02:00 - error:  message=Invalid status code: 77, stack=RangeError: Invalid status code: 77
    at ServerResponse.writeHead (_http_server.js:200:11)
    at ServerResponse._implicitHeader (_http_server.js:191:8)
    at ServerResponse.end (_http_outgoing.js:754:10)
    at ServerResponse.res.end (/home/node/node_modules/express-winston/index.js:241:17)
    at ServerResponse.send (/home/node/node_modules/express/lib/response.js:221:10)
    at /home/node/duplicate-db-controller.js:77:16
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

Express 4.17.1 res.send(int) allways status => changed to  res.send({count: int})
And in receiving end parsing json to proper numeric value